### PR TITLE
Project request serverside

### DIFF
--- a/images-portal-grpc-client/server.go
+++ b/images-portal-grpc-client/server.go
@@ -173,7 +173,7 @@ func getProjectsList(request ProjectsRequest) []string {
 
 	res, err := client.Do(req)
 	if err != nil {
-		http.Error(w, "error response received from API", http.StatusBadRequest)
+		http.Error(w, "error response received from API", res.StatusCode)
 		log.Println(err)
 		return nil
 	}

--- a/images-portal-grpc-client/server.go
+++ b/images-portal-grpc-client/server.go
@@ -159,7 +159,7 @@ func push(w http.ResponseWriter, r *http.Request) {
 func getProjectsList(request ProjectsRequest) []string {
 	req, err := http.NewRequest("GET", request.APIEndpoint+"/apis/project.openshift.io/v1/projects", nil)
 	if err != nil {
-		log.Println("could not create request")
+		http.Error(w, "could not create projects request", http.StatusInternalServerError)
 		log.Println(err)
 		return nil
 	}
@@ -173,7 +173,7 @@ func getProjectsList(request ProjectsRequest) []string {
 
 	res, err := client.Do(req)
 	if err != nil {
-		log.Println("Error response received")
+		http.Error(w, "error response received from API", http.StatusBadRequest)
 		log.Println(err)
 		return nil
 	}
@@ -182,7 +182,7 @@ func getProjectsList(request ProjectsRequest) []string {
 	resJSON := map[string]interface{}{}
 	err = json.NewDecoder(res.Body).Decode(&resJSON)
 	if err != nil {
-		log.Println("Could not decode response body")
+		http.Error(w, "unexpected response received from API", http.StatusInternalServerError)
 		log.Println(err)
 		return nil
 	}

--- a/images-portal-grpc-client/server.go
+++ b/images-portal-grpc-client/server.go
@@ -16,6 +16,15 @@ import (
 	"google.golang.org/grpc"
 )
 
+type ProjectsRequest struct {
+	APIEndpoint string
+	Token       string
+}
+
+type ProjectsResponse struct {
+	ProjectList []string
+}
+
 type LoadRequest struct {
 	S3Key string
 }
@@ -43,10 +52,31 @@ var (
 func main() {
 	http.HandleFunc("/load", load)
 	http.HandleFunc("/push", push)
+	http.HandleFunc("/projects", projects)
 
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		panic(err)
 	}
+}
+
+func projects(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	var request ProjectsRequest
+	if succeeded := getProjectsRequest(w, r, &request); !succeeded {
+		log.Println("could not unmarshal request")
+		http.Error(w, "missing projects request params", http.StatusBadRequest)
+		return
+	}
+
+	projectList := getProjectsList(request)
+	if projectList == nil {
+		log.Println("could not generate project list")
+		http.Error(w, "could not generate project list", http.StatusInternalServerError)
+		return
+	}
+
+	sendProjectsResponse(w, projectList)
 }
 
 func load(w http.ResponseWriter, r *http.Request) {
@@ -128,6 +158,45 @@ func push(w http.ResponseWriter, r *http.Request) {
 
 }
 
+func getProjectsList(request ProjectsRequest) []string {
+	req, err := http.NewRequest("GET", request.APIEndpoint+"/apis/project.openshift.io/v1/projects", nil)
+	if err != nil {
+		log.Println("could not create request")
+		log.Println(err)
+		return nil
+	}
+
+	req.Header.Add("Authorization", "Bearer "+request.Token)
+	req.Header.Add("Accept", "application/json")
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		log.Println("Error response received")
+		log.Println(err)
+		return nil
+	}
+	defer res.Body.Close()
+
+	resJSON := map[string]interface{}{}
+	err = json.NewDecoder(res.Body).Decode(&resJSON)
+	if err != nil {
+		log.Println("Could not decode response body")
+		log.Println(err)
+		return nil
+	}
+
+	var projectList []string
+	for _, item := range resJSON["items"].([]interface{}) {
+		projectList = append(projectList, item.(map[string]interface{})["metadata"].(map[string]interface{})["name"].(string))
+	}
+
+	return projectList
+}
+
 func callGRPCLoad(w http.ResponseWriter, podInterface oc.PodInterface, request LoadRequest) *docker.ImagesList {
 	conn, err := makeGRPCConnection(w, podInterface)
 	if err != nil {
@@ -164,6 +233,14 @@ func makeGRPCConnection(w http.ResponseWriter, podInterface oc.PodInterface) (*g
 	return conn, err
 }
 
+func sendProjectsResponse(w http.ResponseWriter, projectList []string) {
+	projectsResponse := ProjectsResponse{
+		ProjectList: projectList,
+	}
+
+	sendJSONResponse(w, projectsResponse)
+}
+
 func sendLoadResponse(w http.ResponseWriter, podInterface oc.PodInterface, imageList *docker.ImagesList) {
 	podBytes, err := json.Marshal(podInterface)
 	if err != nil {
@@ -189,6 +266,20 @@ func deployPod(w http.ResponseWriter) (oc.PodInterface, error) {
 	}
 	log.Println(podInterface)
 	return podInterface, nil
+}
+
+func getProjectsRequest(w http.ResponseWriter, r *http.Request, request *ProjectsRequest) bool {
+	err := getRequest(w, r, request, "projects")
+	if err != nil {
+		return false
+	}
+	log.Println(request)
+
+	if valid := isValidProjectsRequest(*request); !valid {
+		http.Error(w, "missing load request params", http.StatusBadRequest)
+		return false
+	}
+	return true
 }
 
 func getLoadRequest(w http.ResponseWriter, r *http.Request, request *LoadRequest) bool {
@@ -217,6 +308,10 @@ func getPushRequest(w http.ResponseWriter, r *http.Request, request *PushRequest
 		return false
 	}
 	return true
+}
+
+func isValidProjectsRequest(request ProjectsRequest) bool {
+	return request.APIEndpoint != "" && request.Token != ""
 }
 
 func isValidLoadRequest(request LoadRequest) bool {

--- a/images-portal-grpc-client/server.go
+++ b/images-portal-grpc-client/server.go
@@ -65,14 +65,12 @@ func projects(w http.ResponseWriter, r *http.Request) {
 	var request ProjectsRequest
 	if succeeded := getProjectsRequest(w, r, &request); !succeeded {
 		log.Println("could not unmarshal request")
-		http.Error(w, "missing projects request params", http.StatusBadRequest)
 		return
 	}
 
 	projectList := getProjectsList(request)
 	if projectList == nil {
 		log.Println("could not generate project list")
-		http.Error(w, "could not generate project list", http.StatusInternalServerError)
 		return
 	}
 
@@ -276,7 +274,7 @@ func getProjectsRequest(w http.ResponseWriter, r *http.Request, request *Project
 	log.Println(request)
 
 	if valid := isValidProjectsRequest(*request); !valid {
-		http.Error(w, "missing load request params", http.StatusBadRequest)
+		http.Error(w, "missing projects request params", http.StatusBadRequest)
 		return false
 	}
 	return true

--- a/images-portal-web-client/public/user.js
+++ b/images-portal-web-client/public/user.js
@@ -14,20 +14,13 @@ window.addEventListener('load', () => {
 
         // prepare API request for user's projects
         let xhr = new XMLHttpRequest()
-        xhr.open('GET', window.ENV.OPENSHIFT_API_ENDPOINT + '/apis/project.openshift.io/v1/projects')
-        xhr.setRequestHeader('Authorization', 'Bearer ' + window.USER.ACCESS_TOKEN)
-        xhr.setRequestHeader('Accept', 'application/json')
+        xhr.open('POST', window.ENV.PROJECTS_REQUEST_ROUTE)
 
         // API response callback
         xhr.onreadystatechange = function () {
             if (xhr.readyState == XMLHttpRequest.DONE) {
                 if (xhr.status == 200) {
-                    projectList = JSON.parse(xhr.responseText)
-
-                    // map a list of user's projects
-                    window.USER.PROJECT_LIST = projectList['items'].map(function (project) {
-                        return project['metadata']['name']
-                    })
+                    window.USER.PROJECT_LIST = JSON.parse(xhr.responseText)["ProjectList"]
                 }
                 else {
                     console.log("Could not get user's projects")
@@ -35,7 +28,10 @@ window.addEventListener('load', () => {
             }
         }
 
-        xhr.send()
+        xhr.send(JSON.stringify({
+            APIEndpoint: window.ENV.OPENSHIFT_API_ENDPOINT,
+            Token: window.USER.ACCESS_TOKEN
+        }))
     }
 
     // redirect to authentication screen if access token is not present


### PR DESCRIPTION
Requesting user projects via web client introduces a CORS issue. In order to avoid it, we use the gRPC client to proxy our request.